### PR TITLE
Add local Docker playground for development and testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 .gitignore
 .git
 docker-compose.yml
+shops/
+node_modules/
+vendor/
+.composer-cache/

--- a/README.md
+++ b/README.md
@@ -6,26 +6,127 @@ Die Installation erfolgt in folgenden Schritten:
 
 1. Das Modul über Composer installieren
 
-`composer require endereco/endereco-oxid7-twig-client`
+```bash
+composer require endereco/endereco-oxid7-twig-client
+```
 
 Der Befehl lädt die neuste Version herunter. Um eine spezielle Version zu installieren, zum Beispiel *1.0*, kann
 der Befehl folgenderweise angepasst werden.
 
-`composer require endereco/endereco-oxid7-twig-client:1.0`
+```bash
+composer require endereco/endereco-oxid7-twig-client:1.0
+```
 
 2. Migrationen ausführen
 
-`vendor/bin/oe-eshop-db_migrate migrations:migrate`
+```bash
+vendor/bin/oe-eshop-db_migrate migrations:migrate
+```
 
 [Siehe Dokumentation für Migrationen in Oxid 7](https://docs.oxid-esales.com/developer/en/7.2/development/tell_me_about/migrations.html)
 
 3. Cache leeren und Views neuaufbauen
 
-`vendor/bin/oe-console oe:cache:clear`
-`vendor/bin/oe-eshop-db_views_generate`
+```bash
+vendor/bin/oe-console oe:cache:clear
+vendor/bin/oe-eshop-db_views_generate
+```
 
 4. Modul aktivieren
 
-`vendor/bin/oe-console oe:module:activate endereco-oxid7-client`
+```bash
+vendor/bin/oe-console oe:module:activate endereco-oxid7-client
+```
 
 5. Konfiguration vom Modul im Admin-Bereich vornehmen
+
+---
+
+## Lokaler Playground (Docker)
+
+Mit `playground.sh` lässt sich ein lokaler OXID 7 Testshop starten, in dem das Modul aus dem
+aktuellen Arbeitsverzeichnis live gemountet ist. Änderungen an PHP-Dateien sind sofort wirksam —
+kein Image-Rebuild, kein Container-Neustart.
+
+### Voraussetzungen
+
+- Docker installiert und gestartet (Docker Desktop auf Mac/Windows, Docker Engine auf Linux)
+- Port 80 ist frei (oder beim Start einen anderen Port wählen)
+
+### Starten
+
+```bash
+./playground.sh
+```
+
+Das Skript fragt interaktiv nach:
+
+- **OXID-Version** — `7.1`, `7.2`, `7.3`, `7.4` oder `7.5`
+  (bestimmt die minimale PHP-Version: 8.1 / 8.2 / 8.2 / 8.2 / 8.3)
+- **Image neu bauen?** — nur nötig, wenn sich `docker/Dockerfile` oder
+  `docker/entrypoint.sh` geändert haben
+
+Nach dem Start läuft im Hintergrund automatisch:
+
+- OXID-Shop-Setup inkl. Demo-Daten und Admin-Account
+- Endereco-Modul installieren, aktivieren, Migrationen ausführen
+- Datenbank-Views neu aufbauen
+
+### URLs und Zugangsdaten
+
+    Storefront    http://localhost/
+    Admin         http://localhost/admin/        admin@example.com / admin
+    AdminNeo      http://localhost/adminneo/     Server: oxid7-<version>-db
+                                                 Benutzer: user  Passwort: pwd  DB: db
+
+AdminNeo läuft auf demselben Port wie der Shop (kein eigener Port), unter dem Pfad `/adminneo/`.
+Das Skript gibt beim Start die vollständige AdminNeo-URL mit vorausgefüllten Verbindungsparametern
+aus — nur das Passwort `pwd` muss manuell eingetippt werden.
+
+Der Server-Name im Verbindungsformular lautet `oxid7-<version>-db`, also z. B. `oxid7-7.5-db`
+für OXID 7.3.
+
+Wenn beim Start ein anderer Port gewählt wurde, gilt er für alle drei URLs.
+
+### API-Key hinterlegen
+
+Das Modul ist nach dem Setup aktiv, aber ohne API-Key nicht funktionsfähig.
+Den Key im Admin-Backend unter Extensions → Modules → Endereco Address-Services für Oxid → Settings → Access Data eintragen.
+
+### Shell-Zugang und nützliche CLI-Befehle
+
+Shell im laufenden Container öffnen:
+
+```bash
+docker exec -it oxid7-7.5 bash
+```
+
+Alle folgenden Befehle laufen innerhalb des Containers im Verzeichnis `/var/www/html`.
+
+**Cache leeren** (nach Template- oder Konfigurationsänderungen):
+
+```bash
+vendor/bin/oe-console oe:cache:clear
+```
+
+**Datenbankmigrationen ausführen** (nach Branch-Wechsel mit Schemaänderungen):
+
+```bash
+vendor/bin/oe-eshop-doctrine_migration migrations:migrate
+```
+
+**Modul aktivieren / deaktivieren:**
+
+```bash
+vendor/bin/oe-console oe:module:activate   endereco-oxid7-client
+vendor/bin/oe-console oe:module:deactivate endereco-oxid7-client
+```
+
+### Container stoppen
+
+```bash
+./playground.sh stop
+```
+
+Das Skript erkennt automatisch, welche Version gerade läuft. Laufen mehrere Versionen
+gleichzeitig, erscheint ein kurzes Auswahlmenü.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,61 @@
+ARG PHP_VERSION=8.2
+FROM php:${PHP_VERSION}-apache
+
+ARG OXID_COMPOSER_VERSION=dev-b-7.3-ce
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpng-dev libjpeg-dev libwebp-dev libfreetype6-dev libzip-dev \
+    libxml2-dev libicu-dev libonig-dev libcurl4-openssl-dev \
+    zip unzip curl git default-mysql-client \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+ && docker-php-ext-install -j$(nproc) \
+    pdo_mysql mysqli gd intl zip bcmath soap mbstring xml opcache \
+    curl exif gettext
+
+COPY --from=composer:2.8 /usr/bin/composer /usr/bin/composer
+
+# Install OXID 7 shop.
+RUN composer create-project --no-interaction --ignore-platform-reqs \
+    oxid-esales/oxideshop-project /var/www/html "$OXID_COMPOSER_VERSION"
+
+# Register the module's PSR-4 namespace and merge its runtime dependencies
+# into the shop's composer.json, then resolve only the new packages so the
+# existing lock file stays intact for everything else.
+# The module source is not yet mounted here, so we copy only what the script
+# needs (the module's composer.json) from the build context.
+COPY docker/patch-composer.php /tmp/patch-composer.php
+COPY composer.json /var/www/html/source/modules/endereco/endereco-oxid7-twig-client/composer.json
+RUN cd /var/www/html \
+ && php /tmp/patch-composer.php \
+ && rm /tmp/patch-composer.php \
+ && PKGS=$(cat /tmp/module-packages.txt) && rm /tmp/module-packages.txt \
+ && composer update --no-interaction --no-dev --no-scripts $PKGS \
+ && composer dump-autoload --no-interaction
+
+# AdminNeo — single-file database manager
+RUN mkdir -p /var/www/adminneo \
+ && curl -fsSL -o /var/www/adminneo/index.php \
+    "https://www.adminneo.org/files/latest/mysql_en_default/adminneo-latest.php"
+
+COPY docker/apache.conf /etc/apache2/sites-available/000-default.conf
+RUN a2enmod rewrite headers
+
+COPY docker/php.ini /usr/local/etc/php/conf.d/99-oxid.ini
+
+# oe:setup:shop needs config.inc.php with <placeholder> strings to fill in.
+RUN cp /var/www/html/source/config.inc.php.dist /var/www/html/source/config.inc.php
+
+RUN mkdir -p /var/www/html/source/tmp \
+             /var/www/html/var/log \
+             /var/www/html/var/cache \
+             /var/www/html/var/configuration/shops \
+ && chown -R www-data:www-data /var/www/html
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 80
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -1,0 +1,19 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/source
+    AddDefaultCharset UTF-8
+
+    <Directory /var/www/html/source>
+        Options -Indexes +FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    # AdminNeo database manager at /adminneo
+    Alias /adminneo /var/www/adminneo
+    <Directory /var/www/adminneo>
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/docker/config.inc.php
+++ b/docker/config.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+$this->dbType = 'pdo_mysql';
+$this->dbHost = getenv('MYSQL_HOST') ?: 'db';
+$this->dbPort = 3306;
+$this->dbName = getenv('MYSQL_DATABASE') ?: 'db';
+$this->dbUser = getenv('MYSQL_USER') ?: 'user';
+$this->dbPwd  = getenv('MYSQL_PASSWORD') ?: 'pwd';
+
+$this->sShopURL    = getenv('SHOP_URL') ?: 'http://localhost/';
+$this->sSSLShopURL = getenv('SHOP_URL') ?: 'http://localhost/';
+
+$this->sShopDir    = '/var/www/html/source/';
+$this->sCompileDir = '/var/www/html/source/tmp/';
+
+$this->iUtfMode = 1;
+$this->iDebug   = 0;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+SHOP_DIR=/var/www/html
+MODULE_ID="endereco-oxid7-client"
+MODULE_PATH="${SHOP_DIR}/source/modules/endereco/endereco-oxid7-twig-client"
+SETUP_FLAG="${SHOP_DIR}/.setup-done"
+
+# Refresh the autoloader on every start so the volume-mounted module's classes
+# are always resolvable, even after a container restart without rebuild.
+cd "$SHOP_DIR"
+composer dump-autoload --no-interaction --quiet 2>/dev/null || true
+
+# Clear compiled Twig templates and template chain cache on every start.
+# Without this, switching git branches while the container is running leaves
+# stale compiled templates that no longer match the current source — causing
+# silent failures like enderecoLoadAMSConfig rendering wrong or not at all.
+rm -rf "${SHOP_DIR}/source/tmp/twig_component/" \
+       "${SHOP_DIR}/source/tmp/template_cache/" 2>/dev/null || true
+
+if [ ! -f "$SETUP_FLAG" ]; then
+    # Run setup in the background so Apache can start immediately.
+    # The shop will return 500 until setup is complete — that's expected and documented.
+    (
+        echo "[setup] Waiting for MySQL..."
+        until mysql --ssl=FALSE -h"${MYSQL_HOST}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" \
+              "${MYSQL_DATABASE}" -e "SELECT 1" > /dev/null 2>&1; do
+            echo -n "."
+            sleep 2
+        done
+        echo ""
+        echo "[setup] MySQL ready."
+
+        cd "$SHOP_DIR"
+
+        mkdir -p source/tmp source/export var/log var/cache var/configuration/shops
+        chown -R www-data:www-data source/tmp source/export var/
+
+        echo "[setup] Setting up OXID shop (this takes a few minutes)..."
+        vendor/bin/oe-console oe:setup:shop \
+            --db-host="${MYSQL_HOST}" \
+            --db-port=3306 \
+            --db-name="${MYSQL_DATABASE}" \
+            --db-user="${MYSQL_USER}" \
+            --db-password="${MYSQL_PASSWORD}" \
+            --shop-url="${SHOP_URL}" \
+            --shop-directory="${SHOP_DIR}/source" \
+            --compile-directory="${SHOP_DIR}/source/tmp" \
+            --no-interaction
+
+        echo "[setup] Installing demo data..."
+        vendor/bin/oe-console oe:setup:demodata --no-interaction
+
+        echo "[setup] Creating admin user..."
+        vendor/bin/oe-console oe:admin:create-user \
+            --admin-email="admin@example.com" \
+            --admin-password="admin" \
+            --no-interaction
+
+        echo "[setup] Activating APEX theme..."
+        vendor/bin/oe-console oe:theme:activate apex --no-interaction 2>/dev/null || true
+
+        echo "[setup] Disabling maintenance mode..."
+        mysql --ssl=FALSE -h"${MYSQL_HOST}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" \
+            -e "DELETE FROM oxconfig WHERE OXVARNAME='blShopStopped' AND OXSHOPID='1';" \
+            2>/dev/null || true
+
+        if [ -f "${MODULE_PATH}/metadata.php" ]; then
+            echo "[setup] Installing and activating ${MODULE_ID}..."
+            vendor/bin/oe-console oe:module:install \
+                "source/modules/endereco/endereco-oxid7-twig-client" \
+                --no-interaction 2>/dev/null || true
+
+            vendor/bin/oe-console oe:module:activate "$MODULE_ID" \
+                --no-interaction 2>/dev/null \
+                || echo "[setup] Module activation failed — activate manually in the admin panel."
+
+            echo "[setup] Running module migrations..."
+            # Migrations add required DB columns (e.g. MOJOISO31662 on oxstates).
+            # oe:module:activate does not trigger onActivate (events[] is empty in metadata.php),
+            # so migrations are the only path to schema changes.
+            vendor/bin/oe-eshop-doctrine_migration migrations:migrate --no-interaction 2>/dev/null || true
+
+            echo "[setup] Regenerating database views..."
+            # Views must be rebuilt after migrations add new columns, otherwise OXID
+            # queries against the old view schema and throws "Unknown column" errors.
+            php << 'PHPEOF' || true
+<?php
+define('OXID_PHP_UNIT', false);
+require '/var/www/html/source/bootstrap.php';
+OxidEsales\Eshop\Core\Registry::get(OxidEsales\Eshop\Core\DbMetaDataHandler::class)->updateViews();
+echo "Views regenerated.\n";
+PHPEOF
+        else
+            echo "[setup] Module not found at ${MODULE_PATH}; skipping activation."
+        fi
+
+        echo "[setup] Setting config.inc.php to read-only..."
+        chmod 444 source/config.inc.php 2>/dev/null || true
+
+        rm -rf source/tmp/*
+        chown -R www-data:www-data source/tmp var/
+
+        touch "$SETUP_FLAG"
+        echo "[setup] Setup complete — shop is ready."
+    ) &
+fi
+
+# Remove the setup wizard so OXID never redirects to it.
+# oe:setup:shop handles everything via CLI in the background.
+rm -rf "${SHOP_DIR}/source/Setup"
+
+exec "$@"

--- a/docker/patch-composer.php
+++ b/docker/patch-composer.php
@@ -1,0 +1,38 @@
+<?php
+
+// Patches the shop's composer.json at image build time so that:
+//   1. The module's PSR-4 namespace is resolvable after composer dump-autoload.
+//   2. The module's runtime dependencies (e.g. guzzlehttp/guzzle) are installed
+//      by the subsequent `composer install` step.
+//
+// php/ext-* constraints are platform requirements that composer checks against
+// the runtime environment; they must not be copied into the shop's require block.
+$shopJson   = json_decode(file_get_contents('composer.json'), true);
+$moduleJson = json_decode(
+    file_get_contents('source/modules/endereco/endereco-oxid7-twig-client/composer.json'),
+    true
+);
+
+$shopJson['autoload']['psr-4']['Endereco\\Oxid7Client\\'] =
+    'source/modules/endereco/endereco-oxid7-twig-client/src/';
+
+foreach ($moduleJson['require'] ?? [] as $package => $constraint) {
+    if ($package === 'php' || str_starts_with($package, 'ext-')) {
+        continue;
+    }
+    $shopJson['require'][$package] = $constraint;
+}
+
+file_put_contents(
+    'composer.json',
+    json_encode($shopJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+);
+
+// Write the list of merged packages to a temp file so the Dockerfile can pass
+// them to `composer update` without needing inline PHP in the RUN instruction.
+$packages = array_keys(array_filter(
+    $moduleJson['require'] ?? [],
+    fn($p) => $p !== 'php' && !str_starts_with($p, 'ext-'),
+    ARRAY_FILTER_USE_KEY
+));
+file_put_contents('/tmp/module-packages.txt', implode(' ', $packages));

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,12 @@
+[PHP]
+default_charset = "UTF-8"
+memory_limit = 512M
+upload_max_filesize = 64M
+post_max_size = 64M
+max_execution_time = 120
+display_errors = Off
+log_errors = On
+
+; Disable opcache so edited module files are picked up without cache clearing
+[opcache]
+opcache.enable = 0

--- a/playground.sh
+++ b/playground.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Supported OXID versions.
+# Uses indexed array (not declare -A) for bash 3.2 compatibility (macOS default).
+declare -a versions=("7.1" "7.2" "7.3" "7.4" "7.5")
+
+# Helper: check if element is in array
+containsElement() {
+    local match="$1"
+    shift
+    for e; do [[ "$e" == "$match" ]] && return 0; done
+    return 1
+}
+
+# ./playground.sh stop — detect and remove running playground containers
+if [[ "${1:-}" == "stop" ]]; then
+    running=()
+    while IFS= read -r name; do
+        running+=("$name")
+    done < <(docker ps --format "{{.Names}}" | grep -E "^oxid7-[0-9]+\.[0-9]+$" || true)
+
+    if [ ${#running[@]} -eq 0 ]; then
+        echo "No playground containers are currently running."
+        exit 0
+    fi
+
+    if [ ${#running[@]} -eq 1 ]; then
+        container="${running[0]}"
+    else
+        echo "Multiple playground containers are running:"
+        select container in "${running[@]}"; do
+            [ -n "$container" ] && break
+        done
+    fi
+
+    version="${container#oxid7-}"
+    echo "Stopping oxid7-${version} ..."
+    docker rm -f "oxid7-${version}" "oxid7-${version}-db" 2>/dev/null || true
+    docker network rm "oxid7-${version}-net" 2>/dev/null || true
+    echo "Done."
+    exit 0
+fi
+
+echo "Available OXID 7 versions:"
+printf " - %s\n" "${versions[@]}"
+echo ""
+
+while true; do
+    read -p "Enter the OXID 7 version you want to use: " version
+    if containsElement "$version" "${versions[@]}"; then
+        break
+    fi
+    echo "Invalid version. Please choose from: ${versions[*]}"
+done
+read -p "Force image rebuild? (y/N): " force_rebuild
+
+# Map version to PHP version and Composer project branch
+case "$version" in
+    7.1) php_version="8.1"; composer_version="dev-b-7.1-ce" ;;
+    7.2) php_version="8.2"; composer_version="dev-b-7.2-ce" ;;
+    7.3) php_version="8.2"; composer_version="dev-b-7.3-ce" ;;
+    7.4) php_version="8.2"; composer_version="dev-b-7.4-ce" ;;
+    7.5) php_version="8.3"; composer_version="dev-b-7.5-ce" ;;
+esac
+image_tag="oxid7-playground:${version}"
+container_oxid="oxid7-${version}"
+container_db="oxid7-${version}-db"
+network="oxid7-${version}-net"
+
+# Check if port 80 is already in use
+host_port=80
+blocking_container=$(docker ps --format "{{.Names}}\t{{.Ports}}" \
+    | { grep "0\.0\.0\.0:${host_port}->" || true; } | awk '{print $1}' | head -1)
+if [ -n "$blocking_container" ] || lsof -iTCP:"${host_port}" -sTCP:LISTEN -t > /dev/null 2>&1; then
+    echo ""
+    if [ -n "$blocking_container" ]; then
+        echo "Port ${host_port} is already used by Docker container: ${blocking_container}"
+    else
+        echo "Port ${host_port} is already in use by another process."
+    fi
+    echo "  1) Stop ${blocking_container:-the blocking process} and use port ${host_port}"
+    echo "  2) Use a different port"
+    while true; do
+        read -p "Choice (1/2): " port_choice
+        [[ "$port_choice" == "1" || "$port_choice" == "2" ]] && break
+        echo "Please enter 1 or 2."
+    done
+    if [[ "$port_choice" == "1" ]]; then
+        if [ -n "$blocking_container" ]; then
+            echo "Stopping ${blocking_container} ..."
+            docker rm -f "$blocking_container"
+            blocking_db="${blocking_container}-db"
+            if [ "$(docker ps -aq -f name="^${blocking_db}$")" ]; then
+                docker rm -f "$blocking_db"
+            fi
+            blocking_net="${blocking_container}-net"
+            if docker network inspect "$blocking_net" > /dev/null 2>&1; then
+                docker network rm "$blocking_net"
+            fi
+        else
+            echo "Cannot automatically stop a non-Docker process."
+            echo "Please free port ${host_port} manually and restart."
+            exit 1
+        fi
+    else
+        while true; do
+            read -p "Enter port to use (81-89 or 8080-8089): " host_port
+            if [[ "$host_port" =~ ^8[1-9]$ ]] || \
+               [[ "$host_port" =~ ^808[0-9]$ ]]; then
+                break
+            fi
+            echo "Invalid port. Please enter a port in range 81-89 or 8080-8089."
+        done
+    fi
+fi
+
+if [ "$host_port" -eq 80 ]; then
+    shop_url="http://localhost/"
+else
+    shop_url="http://localhost:${host_port}/"
+fi
+
+echo ""
+echo "Preparing OXID ${version} (PHP ${php_version}) ..."
+
+# Remove existing containers if present
+for name in "$container_oxid" "$container_db"; do
+    if [ "$(docker ps -aq -f name="^${name}$")" ]; then
+        echo "Removing existing container: ${name}"
+        docker rm -f "$name"
+    fi
+done
+
+# Remove existing network if present
+if docker network inspect "$network" > /dev/null 2>&1; then
+    docker network rm "$network"
+fi
+
+# Build OXID image (cached by default; rebuild on request)
+if [[ "$force_rebuild" =~ ^[Yy]$ ]] && docker image inspect "$image_tag" > /dev/null 2>&1; then
+    echo "Removing cached image ${image_tag} for rebuild ..."
+    # Force-remove any leftover containers blocking the image removal
+    blocking=$(docker ps -aq --filter "ancestor=${image_tag}")
+    if [ -n "$blocking" ]; then
+        echo "Removing leftover containers using the image ..."
+        docker rm -f $blocking
+    fi
+    docker rmi "$image_tag"
+fi
+
+if docker image inspect "$image_tag" > /dev/null 2>&1; then
+    echo "Using cached image ${image_tag}."
+else
+    echo "Building image ${image_tag} — this takes a few minutes on first run ..."
+    if ! docker build \
+        --build-arg PHP_VERSION="$php_version" \
+        --build-arg OXID_COMPOSER_VERSION="$composer_version" \
+        -t "$image_tag" \
+        -f docker/Dockerfile \
+        .; then
+        echo "Image build failed. See errors above."
+        exit 1
+    fi
+fi
+
+# Create isolated network
+docker network create "$network"
+
+# Start MySQL
+echo "Starting MySQL ..."
+docker run -d \
+    --name "$container_db" \
+    --network "$network" \
+    --platform linux/x86_64 \
+    -e MYSQL_ROOT_PASSWORD=root \
+    -e MYSQL_DATABASE=db \
+    -e MYSQL_USER=user \
+    -e MYSQL_PASSWORD=pwd \
+    mysql:8.0 \
+    --character-set-server=utf8mb4 \
+    --collation-server=utf8mb4_unicode_ci \
+    --default-authentication-plugin=mysql_native_password \
+    --skip-ssl
+
+# Wait for MySQL to accept connections
+echo "Waiting for MySQL ..."
+until docker exec "$container_db" mysqladmin ping -uroot -proot --silent 2>/dev/null; do
+    echo -n "."
+    sleep 2
+done
+echo ""
+
+# Start OXID shop
+echo "Starting OXID shop ..."
+docker_options=(
+    -d
+    --name "$container_oxid"
+    --network "$network"
+    -e MYSQL_HOST="$container_db"
+    -e MYSQL_DATABASE=db
+    -e MYSQL_USER=user
+    -e MYSQL_PASSWORD=pwd
+    -e SHOP_URL="${shop_url}"
+    -v "$(pwd):/var/www/html/source/modules/endereco/endereco-oxid7-twig-client"
+    -p "${host_port}:80"
+)
+
+if ! docker run "${docker_options[@]}" "$image_tag"; then
+    echo "Failed to start OXID container. See errors above."
+    exit 1
+fi
+
+# Wait for Apache to respond (any HTTP response is fine — 500/503 is normal on first
+# run while the entrypoint is still running oe:database:reset and activating the module).
+echo "Waiting for Apache to be ready ..."
+max_wait=300
+wait_count=0
+until curl -s --max-time 2 -o /dev/null "${shop_url}"; do
+    if [ $wait_count -ge $max_wait ]; then
+        echo ""
+        echo "Apache did not respond in time. Check logs with: docker logs ${container_oxid}"
+        exit 1
+    fi
+    echo -n "."
+    sleep 2
+    (( wait_count += 2 ))
+done
+echo ""
+
+# Stream setup progress until complete so the final message means the shop is truly ready.
+echo ""
+echo "Apache is up. Waiting for shop setup to complete ..."
+docker logs -f "$container_oxid" 2>&1 | while IFS= read -r line; do
+    [[ "$line" == *"[setup]"* ]] && echo "  $line"
+    [[ "$line" == *"Setup complete"* ]] && break
+done || true
+
+echo ""
+echo "OXID 7 (${version}) is ready."
+echo ""
+echo "  Shop:      ${shop_url}"
+echo "  Admin:     ${shop_url}admin/"
+echo "  AdminNeo:  ${shop_url}adminneo/?mysql=${container_db}&username=user&db=db  (pwd: pwd)"
+echo ""
+echo "Default admin credentials:"
+echo "  E-Mail:   admin@example.com"
+echo "  Passwort: admin"
+echo ""
+echo "To stop:   ./playground.sh stop"


### PR DESCRIPTION
Introduces playground.sh and a docker/ setup that spins up a fully configured OXID 7 test shop with the module live-mounted from the working directory. PHP file changes are immediately visible without rebuild. On first start the shop installs itself in the background (demo data, admin user, APEX theme, module activation, migrations, DB view regeneration). Supports OXID 7.1/7.2/7.3/7.4/7.5, and includes AdminNeo as an in-browser database manager.

Ref: DEV-639