### PR TITLE
Fix unguarded HTTP_REFERER read and unsafe __FILE__ fallback in transaction referer

### DIFF
--- a/src/Component/EnderecoService.php
+++ b/src/Component/EnderecoService.php
@@ -117,7 +117,7 @@ class EnderecoService
                             'Content-Type' => 'application/json',
                             'X-Auth-Key' => $sApiKy,
                             'X-Transaction-Id' => $sSessionId,
-                            'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                            'X-Transaction-Referer' => self::getTransactionReferer(),
                             'X-Agent' => $sAgentInfo,
                         ];
                         $request = new Request('POST', $sEndpoint, $newHeaders, json_encode($message));
@@ -143,7 +143,7 @@ class EnderecoService
                     'Content-Type' => 'application/json',
                     'X-Auth-Key' => $sApiKy,
                     'X-Transaction-Id' => 'not_required',
-                    'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                    'X-Transaction-Referer' => self::getTransactionReferer(),
                     'X-Agent' => $sAgentInfo,
                 ];
                 $request = new Request('POST', $sEndpoint, $newHeaders, json_encode($message));
@@ -185,7 +185,7 @@ class EnderecoService
                 'Content-Type' => 'application/json',
                 'X-Auth-Key' => $this->apiKey,
                 'X-Transaction-Id' => $sSessionId,
-                'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                'X-Transaction-Referer' => self::getTransactionReferer(),
                 'X-Agent' => $this->moduleVer,
             ];
 
@@ -247,7 +247,7 @@ class EnderecoService
                 'Content-Type' => 'application/json',
                 'X-Auth-Key' => $this->apiKey,
                 'X-Transaction-Id' => $sSessionId,
-                'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                'X-Transaction-Referer' => self::getTransactionReferer(),
                 'X-Agent' => $this->moduleVer,
             ];
             $request = new Request('POST', $this->endpoint, $newHeaders, json_encode($message));
@@ -270,7 +270,7 @@ class EnderecoService
                     'Content-Type' => 'application/json',
                     'X-Auth-Key' => $this->apiKey,
                     'X-Transaction-Id' => 'not_required',
-                    'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                    'X-Transaction-Referer' => self::getTransactionReferer(),
                     'X-Agent' => $this->moduleVer,
                 ];
                 $request = new Request('POST', $this->endpoint, $newHeaders, json_encode($message));
@@ -281,6 +281,11 @@ class EnderecoService
         }
 
         return $address;
+    }
+
+    public static function getTransactionReferer(): string
+    {
+        return $_SERVER['HTTP_REFERER'] ?? Registry::getConfig()->getShopUrl();
     }
 
     public function generateSessionId()

--- a/src/Controller/ProxyController.php
+++ b/src/Controller/ProxyController.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Request;
 use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\EshopCommunity\Internal\Container\ContainerFactory;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Configuration\Bridge\ModuleConfigurationDaoBridgeInterface;
+use Endereco\Oxid7Client\Component\EnderecoService;
 
 class ProxyController extends \OxidEsales\Eshop\Application\Controller\FrontendController
 {
@@ -62,16 +63,12 @@ class ProxyController extends \OxidEsales\Eshop\Application\Controller\FrontendC
             $transactionId = bin2hex(random_bytes(8));
         }
 
-        $transactionReferer = isset($_SERVER['HTTP_REFERER'])
-            ? (string) $_SERVER['HTTP_REFERER']
-            : __FILE__;
-
         $client = new Client(['timeout' => 8.0]);
         $headers = [
             'Content-Type' => 'application/json',
             'X-Auth-Key' => $apiKey,
             'X-Transaction-Id' => $transactionId,
-            'X-Transaction-Referer' => $transactionReferer,
+            'X-Transaction-Referer' => EnderecoService::getTransactionReferer(),
             'X-Agent' => $agentInfo,
         ];
 

--- a/src/Controller/UserComponent.php
+++ b/src/Controller/UserComponent.php
@@ -121,7 +121,7 @@ class UserComponent extends UserComponent_parent
                             'Content-Type' => 'application/json',
                             'X-Auth-Key' => $sApiKy,
                             'X-Transaction-Id' => $sSessionId,
-                            'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                            'X-Transaction-Referer' => EnderecoService::getTransactionReferer(),
                             'X-Agent' => $sAgentInfo,
                         ];
                         $request = new Request('POST', $sEndpoint, $newHeaders, json_encode($message));
@@ -147,7 +147,7 @@ class UserComponent extends UserComponent_parent
                     'Content-Type' => 'application/json',
                     'X-Auth-Key' => $sApiKy,
                     'X-Transaction-Id' => 'not_required',
-                    'X-Transaction-Referer' => $_SERVER['HTTP_REFERER'] ? $_SERVER['HTTP_REFERER'] : __FILE__,
+                    'X-Transaction-Referer' => EnderecoService::getTransactionReferer(),
                     'X-Agent' => $sAgentInfo,
                 ];
                 $request = new Request('POST', $sEndpoint, $newHeaders, json_encode($message));


### PR DESCRIPTION
EnderecoService read ['HTTP_REFERER'] without isset()/??, emitting a PHP warning whenever the header was missing. All three call sites (EnderecoService, UserComponent, ProxyController) also fell back to __FILE__, leaking the server's absolute file path to the Endereco API.

Solution:
Resolve the referer consistently everywhere: $_SERVER['HTTP_REFERER'] with the shop's base URL (Registry::getConfig()->getShopUrl()) as fallback, extracted into a single public static getTransactionReferer() helper on EnderecoService. UserComponent and ProxyController call it statically instead of duplicating the logic.

Ref: DEV-686