### PR TITLE
Read country from correct API field in prediction mapping

### DIFF
--- a/src/Component/EnderecoService.php
+++ b/src/Component/EnderecoService.php
@@ -201,7 +201,7 @@ class EnderecoService
                 $counter = 0;
                 foreach ($result['predictions'] as $prediction) {
                     $tempAddress = array(
-                        'countryCode' => $prediction['countryCode']
+                        'countryCode' => $prediction['country']
                             ?: $address['countryCode'],
                         'postalCode' => $prediction['postCode'],
                         'locality' => $prediction['cityName'],


### PR DESCRIPTION
The Web API returns the country field as 'country' in the prediction payload, but during server-side validation the mapping logic was trying to read 'countryCode' (the SDK-internal name). This mismatch caused a PHP warning on every prediction and silently fell back to the requested address country, ignoring the API's actual prediction.

Solution:
This commit Changes the mapping to read from $prediction['country'] while keeping the defensive fallback to the requested country.

Ref: DEV-685

Tested manually in Oxid 7 playground.