### PR TITLE
Fix hash-clearing write loop in UserComponent::render

### DIFF
--- a/src/Controller/UserComponent.php
+++ b/src/Controller/UserComponent.php
@@ -42,7 +42,11 @@ class UserComponent extends UserComponent_parent
                 $oUser->oxuser__oxstreetnr->rawValue,
                 $oUser->oxuser__oxaddinfo->rawValue
             );
-            if ($hash !== ($oUser->oxuser__mojoaddresshash->rawValue ?? '')) {
+            $storedHash = $oUser->oxuser__mojoaddresshash->rawValue ?? '';
+            if (
+                $hash !== $storedHash
+                && ($storedHash !== '' || $this->hasAmsDataToInvalidate($oUser, 'oxuser__mojo'))
+            ) {
                 $oUser->oxuser__mojoamsstatus->rawValue = '';
                 $oUser->oxuser__mojoamsts->rawValue = '';
                 $oUser->oxuser__mojoamspredictions->rawValue = '';
@@ -65,7 +69,11 @@ class UserComponent extends UserComponent_parent
                     $oSelectedAddress->oxaddress__oxstreetnr->rawValue,
                     $oSelectedAddress->oxaddress__oxaddinfo->rawValue
                 );
-                if ($hash !== ($oSelectedAddress->oxaddress__mojoaddresshash->rawValue ?? '')) {
+                $storedHash = $oSelectedAddress->oxaddress__mojoaddresshash->rawValue ?? '';
+                if (
+                    $hash !== $storedHash
+                    && ($storedHash !== '' || $this->hasAmsDataToInvalidate($oSelectedAddress, 'oxaddress__mojo'))
+                ) {
                     $oSelectedAddress->oxaddress__mojoamsstatus->rawValue = '';
                     $oSelectedAddress->oxaddress__mojoamsts->rawValue = '';
                     $oSelectedAddress->oxaddress__mojoamspredictions->rawValue = '';
@@ -302,6 +310,21 @@ class UserComponent extends UserComponent_parent
         }
 
         return $return;
+    }
+
+    /**
+     * Whether the object still holds AMS status, timestamp, or predictions
+     * that a hash-mismatch invalidation in render() would need to clear.
+     *
+     * @param \OxidEsales\Eshop\Application\Model\User|\OxidEsales\Eshop\Application\Model\Address $oObject
+     * @param string $sFieldPrefix e.g. 'oxuser__mojo' or 'oxaddress__mojo'
+     * @return bool
+     */
+    private function hasAmsDataToInvalidate($oObject, $sFieldPrefix)
+    {
+        return ($oObject->{$sFieldPrefix . 'amsstatus'}->rawValue ?? '') !== ''
+            || ($oObject->{$sFieldPrefix . 'amsts'}->rawValue ?? '') !== ''
+            || ($oObject->{$sFieldPrefix . 'amspredictions'}->rawValue ?? '') !== '';
     }
 
     /**


### PR DESCRIPTION
For addresses whose stored MOJOADDRESSHASH no longer matches the recalculated hash — in particular every existing address after the hash formula changed — render() cleared the status, timestamp, predictions, and hash, and saved on every page load.
While clearing the hash to '' is intentional (and still happens), this empty string will never match a non-empty recalculated hash. Consequently, the mismatch itself still persists on subsequent page loads, which caused render() to endlessly write back the already-empty state to the database.

Solution:
The clear is now skipped once there is nothing left to invalidate, checked by whether the stored hash or any of the AMS status/timestamp/predictions fields still hold a value. A stale address is therefore invalidated exactly once and stays stable afterward; an address that was never validated and already has empty fields is left untouched. Applied identically to the billing address and the selected shipping address.

Ref: DEV-678

Tested manually in OXID playground. See ticket for details.