### PR TITLE
Fix address edit form not opening after redirect from order confirmation

### DIFF
--- a/views/twig/enderecoconfig_default.html.twig
+++ b/views/twig/enderecoconfig_default.html.twig
@@ -139,6 +139,27 @@
     </script>
     <script async defer src="{{ oViewConf.getModuleUrl('endereco-oxid7-client', 'js/endereco.min.js') }}?ver={{ enderecoclient.sModuleVersion }}"></script>
     {{ include_widget({ cl: "enderecocolor" }) }}
+    {% if 'user' == enderecoclient.sControllerClass %}
+        <script>
+            (function() {
+                const addressType = sessionStorage.getItem('enderecoReopenAddressType');
+                if (!addressType) {
+                    return;
+                }
+                sessionStorage.removeItem('enderecoReopenAddressType');
+
+                document.addEventListener('DOMContentLoaded', function() {
+                    const editButtonSelector = 'shipping_address' === addressType
+                        ? '.dd-edit-shipping-address'
+                        : '#userChangeAddress';
+                    const editButton = document.querySelector(editButtonSelector);
+                    if (editButton) {
+                        editButton.click();
+                    }
+                });
+            })();
+        </script>
+    {% endif %}
 {% endif %}
 
 

--- a/views/twig/extensions/themes/default/page/checkout/order.html.twig
+++ b/views/twig/extensions/themes/default/page/checkout/order.html.twig
@@ -115,6 +115,7 @@
 
                     EAO.waitForAllExtension().then(function() {
                         EAO.onEditAddress.push(function() {
+                            sessionStorage.setItem('enderecoReopenAddressType', 'billing_address');
                             document.querySelectorAll('#orderAddress form')[0].submit();
                         });
 
@@ -266,6 +267,7 @@
 
                         EAO.waitForAllExtension().then(function() {
                             EAO.onEditAddress.push(function() {
+                                sessionStorage.setItem('enderecoReopenAddressType', 'shipping_address');
                                 document.querySelectorAll('#orderAddress form')[1].submit();
                             });
 


### PR DESCRIPTION
On the order confirmation page (cl=order), a stored address that still needs correction shows the check address modal.
Clicking the edit-button redirected the customer to the address step (cl=user), but the edit form never opened there. The address was only shown as a read-only summary, for both billing and shipping, leaving the customer unable to correct the flagged address directly.
The redirect is a real page navigation (a POST to cl=user), so no client-side state carries over on its own.

Solution:
Store which address needs reopening in sessionStorage right before the redirect fires, then consume that flag exactly once on cl=user (it's read and cleared immediately) and click the matching native toggle (#userChangeAddress for billing, .dd-edit-shipping-address for shipping) on DOMContentLoaded. By then the theme's own changeaddress.js has already attached its click handlers to these buttons. The AMS status already seeded on cl=user keeps marking the fields correctly without triggering a new address check.

Ref: DEV-687

Tested manually in playground. See ticket for details.