### PR TITLE
Remove Smart Autofill from backend configuration

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -95,7 +95,6 @@ $aModule = [
         ['group' => 'AMS', 'name' => 'sCHECKPAYPAL', 'type' => 'bool', 'value' => false],
         ['group' => 'AMS', 'name' => 'sAMSBLURTRIGGER', 'type' => 'bool', 'value' => 'true'],
         ['group' => 'AMS', 'name' => 'sAMSResumeSubmit', 'type' => 'bool', 'value' => 'true'],
-        ['group' => 'AMS', 'name' => 'sSMARTFILL', 'type' => 'bool', 'value' => 'true'],
         ['group' => 'AMS', 'name' => 'bChangeFieldsOrder', 'type' => 'bool', 'value' => 'true'],
         ['group' => 'AMS', 'name' => 'bAllowCloseModal', 'type' => 'bool', 'value' => 'true'],
         ['group' => 'AMS', 'name' => 'bConfirmWithCheckbox', 'type' => 'bool', 'value' => 'false'],

--- a/src/Widget/IncludeConfigWidget.php
+++ b/src/Widget/IncludeConfigWidget.php
@@ -162,7 +162,7 @@ class IncludeConfigWidget extends \OxidEsales\Eshop\Application\Component\Widget
             ],
             'ux' => [
                 'resumeSubmit' => $this->toBool($settings['sAMSResumeSubmit'] ?? false),
-                'smartFill' => $this->toBool($settings['sSMARTFILL'] ?? false),
+                'smartFill' => false,
                 'checkExisting' => $this->toBool($settings['sCHECKALL'] ?? false),
                 'changeFieldsOrder' => $this->toBool($settings['bChangeFieldsOrder'] ?? false),
                 'showEmailStatus' => $this->toBool($settings['bShowEmailserviceErrors'] ?? false),

--- a/views/admin_twig/de/endereco_admin_lang.php
+++ b/views/admin_twig/de/endereco_admin_lang.php
@@ -45,7 +45,6 @@ $aLang = [
     'SHOP_MODULE_sAMSSubmitTrigger' => 'Adressprüfung beim Absenden des Formulars auslösen',
     'SHOP_MODULE_sAMSResumeSubmit' => 'Das Absenden des Formulars nach der Adressauswahl fortsetzen',
     'HELP_SHOP_MODULE_sAMSBLURTRIGGER' => 'Ist die Funktion aktiv, wird die Adressprüfung sofort nach Eingabe der Adresse angestoßen. Ist die deaktiviert, erfolg die Prüfung beim Klick auf den "Weiter" Button.',
-    'SHOP_MODULE_sSMARTFILL' => 'Felder bei nur einem verbleibenden Adressvorschlag automatisch ausfüllen (SmartAutocomplete) <i>beta</i>',
     'SHOP_MODULE_bChangeFieldsOrder' => 'Felderreihenfolge optimieren',
 
     'SHOP_MODULE_bAllowCloseModal' => 'Das Schließen des Modals erlauben',

--- a/views/admin_twig/en/endereco_admin_lang.php
+++ b/views/admin_twig/en/endereco_admin_lang.php
@@ -42,7 +42,6 @@ $aLang = [
     'SHOP_MODULE_sAMSBLURTRIGGER' => 'Trigger AddressCheck immediately after entering or changing the address',
     'SHOP_MODULE_sAMSSubmitTrigger' => 'Check address on submit',
     'SHOP_MODULE_sAMSResumeSubmit' => 'Continue submit after the address has been selected',
-    'SHOP_MODULE_sSMARTFILL' => 'Fill fields when input is obvious (SmartFill)',
     'SHOP_MODULE_bChangeFieldsOrder' => 'Optimize address fields order',
 
     'SHOP_MODULE_bAllowCloseModal' => 'Allow customer to close address selection modal',

--- a/views/twig/admin/endereco_settings.html.twig
+++ b/views/twig/admin/endereco_settings.html.twig
@@ -383,16 +383,6 @@
 
             <tr>
                 <td>
-                    {{ translate({ ident: "SHOP_MODULE_sSMARTFILL" }) }}
-                </td>
-                <td>
-                    <input type="checkbox" class="editinput" name="cstrs[sSMARTFILL]" value="true" {% if cstrs.sSMARTFILL == true %}checked="checked"{% endif %}>
-                    &nbsp;{% include "inputhelp.html.twig" with {'sHelpId': help_id("HELP_SHOP_MODULE_sSMARTFILL"), 'sHelpText': help_text("HELP_SHOP_MODULE_sSMARTFILL")} %}
-                </td>
-            </tr>
-
-            <tr>
-                <td>
                     {{ translate({ ident: "SHOP_MODULE_bChangeFieldsOrder" }) }}
                 </td>
                 <td>


### PR DESCRIPTION
Smart Autofill caused more problems than it solved during address entry. Many users did not notice that the feature had already filled in a field and kept typing, resulting in nonsensical address input.

Solution:
IncludeConfigWidget now hardcodes smartFill to false in the SDK config payload, so the feature stays disabled even for shops with a stale sSMARTFILL=true value in the database. The setting, its admin checkbox and the corresponding translations are removed, so it can no longer be re-enabled through the backend either. Currently the feature remains present in the underlying Endereco JS SDK, but is permanently switched off here.

Ref: DEV-368

Tested in OXID playground: no more Smart Fill configuration option in backend, config.ux.smartFill=false permanently, Autocomplete working normally, composer qa without errors