### PR TITLE
Fix double-escaped mojoamspredictions JSON in invadr/deladr form echo

### DIFF
--- a/views/twig/extensions/themes/default/form/fieldset/user_billing.html.twig
+++ b/views/twig/extensions/themes/default/form/fieldset/user_billing.html.twig
@@ -9,7 +9,7 @@
     >
     <input type="hidden" name="invadr[oxuser__mojoamsts]" value="{% if isset( invadr.oxuser__mojoamsts ) %}{{ invadr.oxuser__mojoamsts }}{% else %}{{ oxcmp_user.oxuser__mojoamsts.value }}{% endif %}">
     <input type="hidden" name="invadr[oxuser__mojoamsstatus]" value="{% if isset( invadr.oxuser__mojoamsstatus ) %}{{ invadr.oxuser__mojoamsstatus }}{% else %}{{ oxcmp_user.oxuser__mojoamsstatus.value }}{% endif %}">
-    <input type="hidden" name="invadr[oxuser__mojoamspredictions]" value="{% if isset( invadr.oxuser__mojoamspredictions ) %}{{ invadr.oxuser__mojoamspredictions }}{% else %}{{ oxcmp_user.oxuser__mojoamspredictions.value }}{% endif %}">
+    <input type="hidden" name="invadr[oxuser__mojoamspredictions]" value="{% if isset( invadr.oxuser__mojoamspredictions ) %}{{ invadr.oxuser__mojoamspredictions|raw }}{% else %}{{ oxcmp_user.oxuser__mojoamspredictions.value }}{% endif %}">
     <input type="hidden" name="invadr[oxuser__mojonamescore]" value="{% if isset( invadr.oxuser__mojonamescore ) %}{{ invadr.oxuser__mojonamescore }}{% else %}{{ oxcmp_user.oxuser__mojonamescore.value }}{% endif %}">
 
     <script>

--- a/views/twig/extensions/themes/default/form/fieldset/user_shipping.html.twig
+++ b/views/twig/extensions/themes/default/form/fieldset/user_shipping.html.twig
@@ -9,7 +9,7 @@
     >
 <input type="hidden" name="deladr[oxaddress__mojoamsts]" value="{% if isset( deladr.oxaddress__mojoamsts ) %}{{ deladr.oxaddress__mojoamsts }}{% else %}{{ delivadr.oxaddress__mojoamsts.value }}{% endif %}">
 <input type="hidden" name="deladr[oxaddress__mojoamsstatus]" value="{% if isset( deladr.oxaddress__mojoamsstatus ) %}{{ deladr.oxaddress__mojoamsstatus }}{% else %}{{ delivadr.oxaddress__mojoamsstatus.value }}{% endif %}">
-<input type="hidden" name="deladr[oxaddress__mojoamspredictions]" value="{% if isset( deladr.oxaddress__mojoamspredictions ) %}{{ deladr.oxaddress__mojoamspredictions }}{% else %}{{ delivadr.oxaddress__mojoamspredictions.value }}{% endif %}">
+<input type="hidden" name="deladr[oxaddress__mojoamspredictions]" value="{% if isset( deladr.oxaddress__mojoamspredictions ) %}{{ deladr.oxaddress__mojoamspredictions|raw }}{% else %}{{ delivadr.oxaddress__mojoamspredictions.value }}{% endif %}">
 
 <input type="hidden" name="deladr[oxaddress__mojonamescore]" value="{% if isset( deladr.oxaddress__mojonamescore ) %}{{ deladr.oxaddress__mojonamescore }}{% else %}{{ delivadr.oxaddress__mojonamescore.value }}{% endif %}">
 


### PR DESCRIPTION
user_billing.html.twig and user_shipping.html.twig echo post invadr/deladr values back into the mojoamspredictions hidden field. OXID core already HTML-escapes these values once server-side (checkParamSpecialChars) identically in getInvoiceAddress() and getDeliveryAddress(). Without |raw, Twig's autoescape escapes them again, so " ends up as literal &quot; instead of a real quote and JSON.parse fails in the JS-SDK.
The else branch (direct Field access) is unaffected and left unchanged. The other mojo fields (mojoamsts, mojoamsstatus, mojonamescore) are untouched on purpose: they only ever hold numbers or a fixed snake_case status vocabulary controlled by endereco, never free text.

Solution:
Add |raw to the invadr/deladr echo in both templates.

Ref: DEV-723